### PR TITLE
Created fallback CU

### DIFF
--- a/src/components/wallet/hooks.tsx
+++ b/src/components/wallet/hooks.tsx
@@ -1,5 +1,5 @@
+import { dryrun } from "@/lib/aoConnection";
 import { useAppStore } from "@/store/useAppStore";
-import { dryrun } from "@permaweb/aoconnect/browser";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
 export const useProfile = () => {

--- a/src/lib/aoConnection.ts
+++ b/src/lib/aoConnection.ts
@@ -1,0 +1,95 @@
+import { connect, createDataItemSigner } from "@permaweb/aoconnect";
+
+// Default configuration (NO external imports)
+const AO_CONFIG = {
+  MU_URL: "https://mu.ao-testnet.xyz",
+  CU_URL: "https://cu.ao-testnet.xyz", // Primary CU
+  GATEWAY_URL: "https://arweave.net",
+};
+
+// Backup Compute Units (CU) in case of failure
+const backupCUs = ["https://cu.randao.net", "https://cu1.randao.net"];
+
+// Track the currently active CU
+let currentCU = AO_CONFIG.CU_URL;
+
+/**
+ * Utility function to add timeout
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("Request timed out")), ms);
+    promise
+      .then((res) => {
+        clearTimeout(timer);
+        resolve(res);
+      })
+      .catch((err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+  });
+}
+
+/**
+ * Function to attempt a request with fallbacks.
+ * If a CU fails, it switches and persists the new CU.
+ */
+async function attemptWithFallback<T>(
+  fn: (cuUrl: string) => Promise<T>,
+  timeout = 5000
+): Promise<T> {
+  const cuList = [currentCU, ...backupCUs];
+
+  for (const cuUrl of cuList) {
+    try {
+      console.log(`🔄 Trying CU: ${cuUrl}`);
+      const res = await withTimeout(fn(cuUrl), timeout);
+      
+      if (cuUrl !== currentCU) {
+        console.warn(`✅ Switched to Backup CU: ${cuUrl}`);
+        currentCU = cuUrl; // Persist this CU for future requests
+      }
+
+      return res;
+    } catch (error) {
+      console.warn(`❌ CU Failed: ${cuUrl}, trying next...`, error);
+    }
+  }
+
+  throw new Error("🚨 All Compute Units (CUs) failed after retries.");
+}
+
+// Create a single connection instance (dynamic CU)
+const getConnection = () => connect({ ...AO_CONFIG, CU_URL: currentCU });
+
+/**
+ * Wrapped methods with automatic persistent fallback logic
+ */
+export const message = async (params: any) =>
+  attemptWithFallback((cu) =>
+    connect({ ...AO_CONFIG, CU_URL: cu }).message({
+      ...params,
+      signer: createDataItemSigner(window.arweaveWallet),
+    })
+  );
+
+export const result = async (params: any) =>
+  attemptWithFallback((cu) =>
+    connect({ ...AO_CONFIG, CU_URL: cu }).result({
+      ...params,
+    })
+  );
+
+export const dryrun = async (params: any) =>
+  attemptWithFallback((cu) =>
+    connect({ ...AO_CONFIG, CU_URL: cu }).dryrun({
+      ...params,
+      signer: createDataItemSigner(window.arweaveWallet),
+    })
+  );
+
+// Export other methods normally
+export const { spawn, monitor, unmonitor } = getConnection();
+export { createDataItemSigner };
+export default getConnection();

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -1,4 +1,4 @@
-import { result, results, message, spawn, monitor, unmonitor, dryrun, createDataItemSigner } from "@permaweb/aoconnect";
+import { createDataItemSigner, dryrun, message, result } from "./aoConnection";
 import { COMBAT_PROCESS_ID, GAME_PROCESS_ID, CHAT_PROCESS_ID, DUMZ_TOKEN_PROCESS_ID, TRUNK_TOKEN_PROCESS_ID , BANK_PROCESS_ID, BLACKJACK_PROCESS_ID} from "./utils";
 import { MessageResult } from "@permaweb/aoconnect/dist/lib/result";
 

--- a/src/store/useCombatStore.ts
+++ b/src/store/useCombatStore.ts
@@ -3,7 +3,6 @@ import { Battle } from "@/types/combat";
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { GameStatePages, useGameStore } from "./useGameStore";
-import { result } from "@permaweb/aoconnect/browser";
 import { GAME_PROCESS_ID } from "@/lib/utils";
 import { json } from "stream/consumers";
 


### PR DESCRIPTION
This addition creates a protection layer on top of the connection object from @permaweb/aoconnect.

In the event that dryruns, results/result, or messages take over 15 seconds to respond it will attempt to rerun the request on 2 fallback CU's. In the event these work, they will continue to be used for the rest of the session. Refreshing the page will reset its memory and it will default back to the default AO_CONFIG